### PR TITLE
Simplify the index response and serve on :80

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ test:
 
 black:
 	pipenv run black website/ tests/
+
+push-testing:
+	docker tag kdevops-website:testing ksnavely/website:testing; docker push ksnavely/website:testing

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ build-image:
 	docker build -t kdevops-website:testing .
 
 run-docker:
-	docker run -p 127.0.0.1:5000:5000 kdevops-website:testing
+	docker run -p 127.0.0.1:80:80 kdevops-website:testing
 
 run-docker-gunicorn:
-	docker run -p 127.0.0.1:5000:5000 kdevops-website:testing pipenv run gunicorn -c /opt/website2/gunicorn.conf.py server:app
+	docker run -p 127.0.0.1:80:80 kdevops-website:testing pipenv run gunicorn -c /opt/website2/gunicorn.conf.py server:app
 
 run-docker-bash:
-	docker run -it -p 127.0.0.1:5000:5000 kdevops-website:testing /bin/bash
+	docker run -it -p 127.0.0.1:80:80 kdevops-website:testing /bin/bash
 
 run-local-flask:
 	FLASK_APP=website/server flask run

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make test
 make build-image
 make run-docker-gunicorn
 
-curl 127.0.0.1:5000/version
+curl 127.0.0.1:80/version
   {"ok":true,"version":"0.1.0"}
 ```
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,3 +1,3 @@
-bind = '0.0.0.0:5000'
+bind = '0.0.0.0:80'
 reuse_port = True
 chdir = '/opt/website2/website'

--- a/website/server/views/frontpage.py
+++ b/website/server/views/frontpage.py
@@ -1,8 +1,8 @@
 import arrow
-from flask import redirect, render_template, request, url_for
+from flask import jsonify, redirect, render_template, request, url_for
 from flask_login import login_required
 
-from website import blog
+from website import __version__, blog
 
 
 COUNT = 5
@@ -12,6 +12,19 @@ SKIP = 0
 
 
 def index():
+    """
+    Returns version JSON.
+    """
+    info = {
+        "ok": True,
+        "version": __version__,
+        "kube": "ification"
+    }
+
+    return jsonify(info)
+
+
+def orig_index():
     """
     Returns the frontpage.
     """


### PR DESCRIPTION
This combo worked well deployed in Kube behind a service, ingress, and ALB.

```
curl http://dev.kdevops.com/
{"kube":"ification","ok":true,"version":"0.1.0"}
```